### PR TITLE
Fix: markers wiped on death

### DIFF
--- a/forge/src/main/java/com/imjustdoom/doomsmarkers/ServerListener.java
+++ b/forge/src/main/java/com/imjustdoom/doomsmarkers/ServerListener.java
@@ -12,4 +12,16 @@ public class ServerListener {
         ServerPlayer player = (ServerPlayer) event.getEntity();
         player.connection.send(new ClientboundCustomPayloadPacket(new ClientboundMarkerSyncPayload(((ServerPlayerInterface) player).getMarkers())));
     }
+
+    // Forge fires PlayerEvent.Clone on respawn after death and on End -> Overworld
+    // return. The Marker list lives in a @Unique mixin field on ServerPlayer, which
+    // vanilla restoreFrom(...) does not copy, so without this handler all markers
+    // would be silently wiped on the next autosave following a respawn.
+    @SubscribeEvent
+    public static void onPlayerClone(PlayerEvent.Clone event) {
+        if (!(event.getOriginal() instanceof ServerPlayerInterface oldPlayer)) return;
+        if (!(event.getEntity() instanceof ServerPlayerInterface newPlayer)) return;
+        newPlayer.getMarkers().clear();
+        newPlayer.getMarkers().addAll(oldPlayer.getMarkers());
+    }
 }


### PR DESCRIPTION
Hit this on 1.20.1 (1.3.0 release): all my markers vanish the moment I respawn after dying. Same thing happens coming back from the End. The log just says `No Markers exist for <player> to save` on the next autosave and that's that.

Cause is simple. `ServerPlayerMixin` keeps the marker list in a `@Unique` field:

```java
@Unique public final List<Marker> doomsMarkers$markers = new ArrayList<>();
```

When you respawn, MC builds a fresh `ServerPlayer` and runs `restoreFrom(...)` on it. `restoreFrom` only knows about vanilla state (recipe book, advancements, score). The mixin field on the new instance stays as the empty list it was initialised to. The old player carrying all the markers gets discarded without being persisted, and the next autosave writes the empty list to player.dat.

Forge already fires `PlayerEvent.Clone` on the respawn / End-return path for exactly this. So just hook it in `ServerListener` and copy the list across:

```java
@SubscribeEvent
public static void onPlayerClone(PlayerEvent.Clone event) {
    if (!(event.getOriginal() instanceof ServerPlayerInterface oldPlayer)) return;
    if (!(event.getEntity() instanceof ServerPlayerInterface newPlayer)) return;
    newPlayer.getMarkers().clear();
    newPlayer.getMarkers().addAll(oldPlayer.getMarkers());
}
```

`ServerListener.class` is already on `MinecraftForge.EVENT_BUS` from `DoomsMarkersForge`, so no extra wiring.

Tested by applying the same patch to the 1.20.1 source (commit 6381329), building locally and running it on Forge 47.4.13. Repro is to place a marker, die, respawn. Before the patch the marker list comes back empty and the next autosave logs the "No Markers exist" line. After the patch the markers stay, the death marker shows up alongside them, and the autosave logs `Saved N markers for <player>`.

Heads up: Fabric (no `ServerPlayerEvents.COPY_FROM` handler anywhere) and NeoForge (the inline `PlayerLoggedInEvent` lambda in `DoomsMarkersNeoForge` has no `PlayerEvent.Clone` counterpart) look like they have the same bug. Didn't touch them since I only had Forge to test on.